### PR TITLE
Fix student photo loading with fallback handling

### DIFF
--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -279,6 +279,7 @@ const carregarAlunos = async () => {
       if (alunosCarregados.length > 0) {
         pessoas.value = alunosCarregados
         emit('updateTotal', pessoas.value)
+        pessoas.value.forEach(resolverFoto)
         return
       }
     }

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -352,6 +352,25 @@ const getTextoBadge = () => {
 const atualizarEstadoExcel = () => {
   temDadosExcel.value = temDadosPlanilha()
 }
+
+// Normaliza o nome do aluno para coincidir com o nome do arquivo
+const normalizarNomeArquivo = (nome) => {
+  if (!nome) return ''
+  return String(nome)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_')
+}
+
+// Retorna a URL da foto do aluno no padrão /fotos/{curso}/{turma}/{nome}.jpg
+const getFoto = (pessoa) => {
+  if (pessoa?.foto) return pessoa.foto
+  const nomeNormalizado = normalizarNomeArquivo(pessoa?.nome || '')
+  if (!nomeNormalizado || !props.curso || !props.turma) return ''
+  return `/fotos/${props.curso}/${props.turma}/${nomeNormalizado}.jpg`
+}
 </script>
 
 <style scoped>

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -183,7 +183,7 @@
           <!-- Avatar/Foto -->
           <div class="text-center pt-6 pb-2">
             <v-avatar size="80" class="elevation-4">
-              <v-img :src="fotoSrcs[pessoa.id] || getFoto(pessoa)" cover>
+              <v-img :src="fotoSrcs[getPessoaKey(pessoa)] || getFoto(pessoa)" cover>
                 <template #error>
                   <v-icon size="40" color="grey-lighten-1">mdi-account</v-icon>
                 </template>
@@ -300,7 +300,7 @@ const carregarAlunos = async () => {
 }
 
 const abrirModal = (pessoa) => {
-  const foto = fotoSrcs.value[pessoa.id] || getFoto(pessoa)
+  const foto = fotoSrcs.value[getPessoaKey(pessoa)] || getFoto(pessoa)
   emit('selectPessoa', { ...pessoa, foto })
 }
 
@@ -392,16 +392,18 @@ const buildCandidatos = (pessoa) => {
 }
 
 // Tenta resolver a primeira URL existente
+const getPessoaKey = (pessoa) => pessoa?.id || pessoa?.matricula || baseNome(pessoa?.nome || '')
+
 const resolverFoto = (pessoa) => {
   if (!pessoa || !props.curso || !props.turma) return
-  const id = pessoa.id
-  if (!id || fotoSrcs.value[id]) return
+  const key = getPessoaKey(pessoa)
+  if (!key || fotoSrcs.value[key]) return
   const candidatos = buildCandidatos(pessoa)
   const tryNext = (i) => {
-    if (i >= candidatos.length) { fotoSrcs.value[id] = ''; return }
+    if (i >= candidatos.length) { fotoSrcs.value[key] = ''; return }
     const url = candidatos[i]
     const img = new Image()
-    img.onload = () => { fotoSrcs.value[id] = url }
+    img.onload = () => { fotoSrcs.value[key] = url }
     img.onerror = () => tryNext(i + 1)
     img.src = url
   }

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -377,7 +377,7 @@ const nomeComSep = (nome, sep) => baseNome(nome).replace(/\s+/g, sep)
 // Candidatos de arquivo para tentar
 const buildCandidatos = (pessoa) => {
   const nome = pessoa?.nome || ''
-  const raw = String(nome).trim().replace(/\\s+/g, ' ')
+  const raw = String(nome).trim().replace(/\s+/g, ' ')
   const nomes = [
     // Normalizados
     nomeComSep(nome, '_'),

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -388,7 +388,7 @@ const buildCandidatos = (pessoa) => {
     raw.replace(/\s+/g, '-'),
     raw
   ]
-  const exts = ['.jpg', '.jpeg', '.png']
+  const exts = ['.jpg', '.jpeg', '.png', '.webp']
   const candidatos = []
   for (const n of nomes) {
     for (const ext of exts) {

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -298,7 +298,8 @@ const carregarAlunos = async () => {
 }
 
 const abrirModal = (pessoa) => {
-  emit('selectPessoa', pessoa)
+  const foto = getFoto(pessoa)
+  emit('selectPessoa', { ...pessoa, foto })
 }
 
 const atualizarDados = async () => {

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -377,10 +377,16 @@ const nomeComSep = (nome, sep) => baseNome(nome).replace(/\s+/g, sep)
 // Candidatos de arquivo para tentar
 const buildCandidatos = (pessoa) => {
   const nome = pessoa?.nome || ''
+  const raw = String(nome).trim().replace(/\\s+/g, ' ')
   const nomes = [
-    nomeComSep(nome, '_'), // underscores
-    nomeComSep(nome, '-'), // hyphens
-    baseNome(nome) // com espaço
+    // Normalizados
+    nomeComSep(nome, '_'),
+    nomeComSep(nome, '-'),
+    baseNome(nome),
+    // Originais (com acentos/caixa)
+    raw.replace(/\s+/g, '_'),
+    raw.replace(/\s+/g, '-'),
+    raw
   ]
   const exts = ['.jpg', '.jpeg', '.png']
   const candidatos = []

--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -183,18 +183,11 @@
           <!-- Avatar/Foto -->
           <div class="text-center pt-6 pb-2">
             <v-avatar size="80" class="elevation-4">
-              <v-img
-                v-if="pessoa.foto"
-                :src="pessoa.foto"
-                cover
-              />
-              <v-icon
-                v-else
-                size="40"
-                color="grey-lighten-1"
-              >
-                mdi-account
-              </v-icon>
+              <v-img :src="getFoto(pessoa)" cover>
+                <template #error>
+                  <v-icon size="40" color="grey-lighten-1">mdi-account</v-icon>
+                </template>
+              </v-img>
             </v-avatar>
           </div>
 

--- a/src/components/carometro/pessoaModal.vue
+++ b/src/components/carometro/pessoaModal.vue
@@ -9,7 +9,11 @@
       >
         <div class="d-flex align-center">
           <v-avatar size="64" class="elevation-8" :style="{ border: '4px solid rgba(255,255,255,0.3)' }">
-            <v-img v-if="pessoa.foto" :src="pessoa.foto" />
+            <v-img v-if="pessoa.foto" :src="pessoa.foto">
+              <template #error>
+                <v-icon color="white" size="32">mdi-account</v-icon>
+              </template>
+            </v-img>
             <v-icon v-else color="white" size="32">mdi-account</v-icon>
           </v-avatar>
           <div class="ml-4">
@@ -34,7 +38,13 @@
             <v-row dense>
               <!-- foto -->
               <v-col cols="12" md="3" class="d-flex justify-center">
-                <v-img v-if="pessoa.foto" :src="pessoa.foto" height="240" width="180" rounded="lg" cover class="elevation-6" />
+                <v-img v-if="pessoa.foto" :src="pessoa.foto" height="240" width="180" rounded="lg" cover class="elevation-6">
+                  <template #error>
+                    <v-sheet height="240" width="180" rounded="lg" class="elevation-6 d-flex align-center justify-center">
+                      <v-icon size="80" color="grey-lighten-2">mdi-account</v-icon>
+                    </v-sheet>
+                  </template>
+                </v-img>
                 <v-sheet v-else height="240" width="180" rounded="lg" class="elevation-6 d-flex align-center justify-center">
                   <v-icon size="80" color="grey-lighten-2">mdi-account</v-icon>
                 </v-sheet>


### PR DESCRIPTION
## Purpose

The users were experiencing issues with student photos not displaying in the carometro (student directory) interface. Only one student's photo (Alex Marculino Gonçalves Silva) was showing up, while all other students appeared without photos. The goal was to fix the photo loading mechanism to properly display all student photos from the `/fotos/CAI/M2A/` directory structure.

## Code changes

- **Enhanced photo resolution system**: Added a comprehensive photo URL resolution mechanism that tries multiple filename variations (with/without accents, different separators, various extensions)
- **Implemented photo caching**: Added `fotoSrcs` reactive cache to store resolved photo URLs and avoid repeated lookups
- **Added error handling**: Implemented fallback icons when photo loading fails using Vue's `#error` template slot
- **Improved name normalization**: Created robust functions to handle name variations, accents removal, and different separator formats
- **Enhanced Excel data handling**: Added better error handling and validation for Excel file processing to prevent crashes
- **Updated modal component**: Added error handling for photos in the person modal dialog

The changes ensure that student photos are properly loaded using various naming conventions and provide graceful fallbacks when photos are not found.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/813032f2a5ec4168b715174693e49156/mystic-studio)

👀 [Preview Link](https://813032f2a5ec4168b715174693e49156-mystic-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>813032f2a5ec4168b715174693e49156</projectId>-->
<!--<branchName>mystic-studio</branchName>-->