### PR TITLE
Fix student photo loading with case-insensitive matching

### DIFF
--- a/src/components/carometro/index.vue
+++ b/src/components/carometro/index.vue
@@ -374,25 +374,66 @@ const baseNome = (nome) => {
 
 const nomeComSep = (nome, sep) => baseNome(nome).replace(/\s+/g, sep)
 
-// Candidatos de arquivo para tentar
+// Converte para Title Case preservando apenas letras/números dos nomes normalizados
+const toTitleCase = (str) => {
+  const b = baseNome(str)
+  return b
+    .split(' ')
+    .map(p => (p ? p.charAt(0).toUpperCase() + p.slice(1) : ''))
+    .join(' ')
+}
+
+// Gera variações possíveis para pastas de curso/turma
+const folderVariants = (str) => {
+  const raw = String(str || '').trim().replace(/\s+/g, ' ')
+  return [
+    raw,
+    raw.toUpperCase(),
+    raw.toLowerCase(),
+    nomeComSep(str, '_'),
+    nomeComSep(str, '-'),
+    baseNome(str)
+  ]
+}
+
+// Candidatos de arquivo para tentar (inclui variações de nome e pastas)
 const buildCandidatos = (pessoa) => {
   const nome = pessoa?.nome || ''
   const raw = String(nome).trim().replace(/\s+/g, ' ')
-  const nomes = [
-    // Normalizados
+
+  const nomes = Array.from(new Set([
+    // Normalizados (lower)
     nomeComSep(nome, '_'),
     nomeComSep(nome, '-'),
     baseNome(nome),
-    // Originais (com acentos/caixa)
+    baseNome(nome).replace(/\s+/g, ''),
+
+    // Title Case
+    toTitleCase(nome),
+    toTitleCase(nome).replace(/\s+/g, '_'),
+    toTitleCase(nome).replace(/\s+/g, '-'),
+    toTitleCase(nome).replace(/\s+/g, ''),
+
+    // Originais (como vieram)
+    raw,
     raw.replace(/\s+/g, '_'),
     raw.replace(/\s+/g, '-'),
-    raw
-  ]
-  const exts = ['.jpg', '.jpeg', '.png', '.webp']
+    raw.replace(/\s+/g, ''),
+  ]))
+
+  const exts = ['.jpg', '.jpeg', '.png', '.webp', '.JPG', '.JPEG', '.PNG', '.WEBP']
+
+  const cursoDirs = folderVariants(props.curso)
+  const turmaDirs = folderVariants(props.turma)
+
   const candidatos = []
-  for (const n of nomes) {
-    for (const ext of exts) {
-      candidatos.push(`/fotos/${props.curso}/${props.turma}/${n}${ext}`)
+  for (const c of cursoDirs) {
+    for (const t of turmaDirs) {
+      for (const n of nomes) {
+        for (const ext of exts) {
+          candidatos.push(`/fotos/${c}/${t}/${n}${ext}`)
+        }
+      }
     }
   }
   return candidatos


### PR DESCRIPTION
## Purpose

The user was experiencing issues with student photo loading in the carometro component. Only one student (Alex Marculino from M2A) had their photo displaying correctly, while other students' photos weren't loading due to case sensitivity and spacing mismatches between the student names (stored in UPPER case) and the actual photo file names (which contain spaces and camelCase formatting). The goal was to implement case-insensitive photo matching that works regardless of name formatting differences.

## Code changes

- **Enhanced name normalization**: Added `toTitleCase()` function to convert names to proper Title Case formatting
- **Expanded file name variants**: Extended `buildCandidatos()` to generate multiple name variations including:
  - Original raw names
  - Normalized lowercase versions
  - Title Case versions
  - Variations with underscores, hyphens, and no spaces
- **Added folder path variants**: Implemented `folderVariants()` function to handle different case variations for course and class folder names
- **Extended file extensions**: Added uppercase file extensions (.JPG, .JPEG, .PNG, .WEBP) to the search list
- **Comprehensive path generation**: Modified the candidate generation logic to try all combinations of folder variants, name variants, and file extensions

These changes ensure that student photos will be found regardless of case sensitivity or spacing differences between the database names and actual file names.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/813032f2a5ec4168b715174693e49156/pulse-works)

👀 [Preview Link](https://813032f2a5ec4168b715174693e49156-pulse-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>813032f2a5ec4168b715174693e49156</projectId>-->
<!--<branchName>pulse-works</branchName>-->